### PR TITLE
Allow PR tests to pass without IAC changes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,16 +1,8 @@
 name: Pull Request Tests
 
 on:
-  merge_group: {}
+  merge_group:
   pull_request:
-    paths-ignore:
-      # The ignore only works only if changes to the main branch only include the following files.
-      # So if the commit only contain .md changes but the PR change contain more, the ignore fails
-      # https://github.com/actions/runner/issues/2324#issuecomment-1703345084
-      - '**.md'
-      - '**.svg'
-      - '**.drawio'
-      - '**.png'
     types:
       - opened
       - reopened
@@ -23,28 +15,27 @@ on:
 permissions: read-all
 
 # Actions Used (please keep this documented here as added)
-#  https://github.com/marketplace/actions/checkout
-#  https://github.com/marketplace/actions/setup-python
-#  https://github.com/marketplace/actions/trufflehog-oss
-#  https://github.com/marketplace/actions/checkout
-#  https://github.com/marketplace/actions/cache
-#  https://github.com/actions-rust-lang/setup-rust-toolchain
+#  https://github.com/marketplace/actions/checkout (v7)
+#  https://github.com/marketplace/actions/setup-node-js-environment (v7)
+#  https://github.com/marketplace/actions/setup-pnpm (v6)
+#  https://github.com/marketplace/actions/trufflehog-oss (v3.96.0)
+#  https://github.com/dorny/paths-filter (v4)
 
 jobs:
   pre-commit-lint-security:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft && github.repository != 'OrcaBus/template-service-base' }}
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'pnpm'
 
       - run: corepack enable
@@ -62,7 +53,7 @@ jobs:
           pip3 install pre-commit detect-secrets black ggshield
 
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.34.0
+        uses: trufflesecurity/trufflehog@v3.96.0
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}
@@ -77,18 +68,45 @@ jobs:
         run: |
           make check
 
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.ts'
+              - '**/*.sh'
+              - '**/*.py'
+              - '**/package.json'
+              - '**/pnpm-lock.yaml'
+              - 'infrastructure/**'
+              - 'app/**'
+              - 'test/**'
+              - 'Makefile'
+              - '.github/**'
   test-iac:
     runs-on: ubuntu-22.04-arm
     # Template service base is broken with
-    if: ${{ !github.event.pull_request.draft && github.repository != 'OrcaBus/template-service-base' }}
+    if: >-
+      !github.event.pull_request.draft &&
+      github.repository != 'OrcaBus/template-service-base' &&
+      needs.check-changes.outputs.should_test == 'true'
+    needs: check-changes
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'pnpm'
 
       - run: corepack enable
@@ -96,3 +114,17 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - run: pnpm test
+
+  # This is the job you set as "required" in branch protection
+  ci-gate:
+    runs-on: ubuntu-latest
+    needs: test-iac
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.test-iac.result }}" == "failure" ]]; then
+            echo "Tests failed"
+            exit 1
+          fi
+          echo "CI passed (tests passed or were skipped)"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -73,7 +73,7 @@ jobs:
     outputs:
       should_test: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: dorny/paths-filter@v4
@@ -118,11 +118,15 @@ jobs:
   # This is the job you set as "required" in branch protection
   ci-gate:
     runs-on: ubuntu-latest
-    needs: test-iac
+    needs: [pre-commit-lint-security, check-changes, test-iac]
     if: always()
     steps:
       - name: Check results
         run: |
+          if [[ "${{ needs.pre-commit-lint-security.result }}" == "failure" ]]; then
+            echo "Lint/security checks failed"
+            exit 1
+          fi
           if [[ "${{ needs.test-iac.result }}" == "failure" ]]; then
             echo "Tests failed"
             exit 1

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -91,6 +91,9 @@ jobs:
               - 'test/**'
               - 'Makefile'
               - '.github/**'
+              - 'cdk.json'
+              - 'tsconfig.json'
+              - 'jest.config.*'
   test-iac:
     runs-on: ubuntu-22.04-arm
     # Template service base is broken with

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -96,7 +96,7 @@ jobs:
               - 'jest.config.*'
   test-iac:
     runs-on: ubuntu-22.04-arm
-    # Template service base is broken with
+    # Excluded for template-service-base which has no application code to test
     if: >-
       !github.event.pull_request.draft &&
       github.repository != 'OrcaBus/template-service-base' &&

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,14 +1,13 @@
 name: Pull Request Tests
 
 on:
-  merge_group:
+  merge_group: {}
   pull_request:
     types:
       - opened
       - reopened
       - synchronize
       - ready_for_review
-      - auto_merge_enabled
     branches:
       - main
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.pre-commit-lint-security.result }}" != "success" ]]; then
+          if [[ "${{ needs.pre-commit-lint-security.result }}" != "success" && "${{ needs.pre-commit-lint-security.result }}" != "skipped" ]]; then
             echo "Lint/security checks did not succeed (result: ${{ needs.pre-commit-lint-security.result }})"
             exit 1
           fi

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -130,6 +130,10 @@ jobs:
             echo "Lint/security checks failed"
             exit 1
           fi
+          if [[ "${{ needs.check-changes.result }}" == "failure" ]]; then
+            echo "Change detection failed"
+            exit 1
+          fi
           if [[ "${{ needs.test-iac.result }}" == "failure" ]]; then
             echo "Tests failed"
             exit 1

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -126,16 +126,16 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.pre-commit-lint-security.result }}" == "failure" ]]; then
-            echo "Lint/security checks failed"
+          if [[ "${{ needs.pre-commit-lint-security.result }}" != "success" ]]; then
+            echo "Lint/security checks did not succeed (result: ${{ needs.pre-commit-lint-security.result }})"
             exit 1
           fi
-          if [[ "${{ needs.check-changes.result }}" == "failure" ]]; then
-            echo "Change detection failed"
+          if [[ "${{ needs.check-changes.result }}" != "success" ]]; then
+            echo "Change detection did not succeed (result: ${{ needs.check-changes.result }})"
             exit 1
           fi
-          if [[ "${{ needs.test-iac.result }}" == "failure" ]]; then
-            echo "Tests failed"
+          if [[ "${{ needs.test-iac.result }}" != "success" && "${{ needs.test-iac.result }}" != "skipped" ]]; then
+            echo "Tests did not succeed (result: ${{ needs.test-iac.result }})"
             exit 1
           fi
           echo "CI passed (tests passed or were skipped)"


### PR DESCRIPTION
Enhances PR workflow with conditional testing and refined gatekeeping.

This update refactors the pull request test workflow to introduce conditional execution of Infrastructure-as-Code (IaC) tests based on code changes and adds a new gatekeeping job for comprehensive status aggregation. It also updates several GitHub Action and Node.js versions. **Changes**

`pr-tests.yml`:
Removed the `paths-ignore` configuration from the pull_request trigger, ensuring tests run for all file changes.
Upgraded GitHub Action versions: `actions/checkout` (v4 to v7), `pnpm/action-setup` (v4 to v6), `actions/setup-node` (v4 to v7), and `trufflesecurity/trufflehog` (v3.34.0 to v3.96.0).
Updated Node.js version for test jobs from `22.x` to `24.x`.
Introduced a new job, `check-changes`, which uses `dorny/paths-filter@v4` to determine if specific code or configuration files have changed. It outputs a `should_test` boolean.
Modified the `test-iac` job's `if` condition to depend on the `check-changes` job's output (`needs.check-changes.outputs.should_test == 'true'`), ensuring IaC tests only run when relevant files are modified.
Removed the repository-specific exclusion (`github.repository != 'OrcaBus/template-service-base'`) from the `pre-commit-lint-security` job's `if` condition.
Added a new `ci-gate` job that depends on `pre-commit-lint-security`, `check-changes`, and `test-iac`. This job checks the results of all preceding jobs, failing if any required job fails, but passing if `test-iac` is skipped.
**Impact**

The CI/CD pipeline is now more efficient, as IaC tests are conditionally skipped if pull requests only contain changes to non-code files (e.g., documentation, images).
The overall CI status for pull requests is more robust, with the `ci-gate` job providing a unified pass/fail status that correctly handles skipped conditional tests.
All updated GitHub Actions and Node.js versions ensure compatibility, security, and performance improvements for the workflow steps.
The `pre-commit-lint-security` job will now run consistently across all repositories without conditional exclusions.
Changes to formerly ignored paths (like `.md` files) will now trigger the workflow, though IaC tests might still be skipped if only these non-code files change.