### PR TITLE
chore: upgrade @orcabus/platform-cdk-constructs to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "2.259.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "1.7.1",
+    "@orcabus/platform-cdk-constructs": "1.7.2",
     "aws-cdk-lib": "^2.262.1",
     "constructs": "^10.7.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2.259.0-alpha.0
         version: 2.259.0-alpha.0(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1)
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.7.1
-        version: 1.7.1(@aws-cdk/aws-lambda-python-alpha@2.259.0-alpha.0(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1))(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1)
+        specifier: 1.7.2
+        version: 1.7.2(@aws-cdk/aws-lambda-python-alpha@2.259.0-alpha.0(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1))(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1)
       aws-cdk-lib:
         specifier: ^2.262.1
         version: 2.262.1(constructs@10.7.1)
@@ -446,8 +446,8 @@ packages:
       '@emnapi/core': ^2.0.0-alpha.3
       '@emnapi/runtime': ^2.0.0-alpha.3
 
-  '@orcabus/platform-cdk-constructs@1.7.1':
-    resolution: {integrity: sha512-9/jesp4Y2RVJJ/kcjk3afJlooVNmnNxSGLfRCQcFJDhjp4UGY3/wbNaHxpEpPRV9bw145V12Pt0+0zvHe5NouQ==}
+  '@orcabus/platform-cdk-constructs@1.7.2':
+    resolution: {integrity: sha512-oayS7Cpe94ZrwLIzKgDuHC1uOeN8r88CpgJDo3NIOyLp4wVCgAtTFPA+GL/mAL43PICLC++rfQcUFcgbx60IhQ==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2328,7 +2328,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.7.1(@aws-cdk/aws-lambda-python-alpha@2.259.0-alpha.0(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1))(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1)':
+  '@orcabus/platform-cdk-constructs@1.7.2(@aws-cdk/aws-lambda-python-alpha@2.259.0-alpha.0(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1))(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.259.0-alpha.0(aws-cdk-lib@2.262.1(constructs@10.7.1))(constructs@10.7.1)
       aws-cdk-lib: 2.262.1(constructs@10.7.1)


### PR DESCRIPTION
Upgrade `@orcabus/platform-cdk-constructs` from `1.7.1` to `1.7.2`.